### PR TITLE
Home folder pairs

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,10 +1,10 @@
 <!--
-  ~ Copyright (C) 2016 Robert A. Wallis, All Rights Reserved
+  ~ Copyright (C) 2018 Robert A. Wallis, All Rights Reserved
   -->
-<idea-plugin version="2">
+<idea-plugin>
     <id>com.smilingrob.gitpair</id>
     <name>Git Pair</name>
-    <version>1.3</version>
+    <version>1.4</version>
     <vendor email="smilingrob@gmail.com" url="http://smilingrob.com">Robert Wallis</vendor>
 
     <description><![CDATA[
@@ -12,7 +12,7 @@
     See who is paired, and pick your teammates in the status bar.
     Changes the name and email address of your local git user so when you commit you commit as all of the checked people.
     <br />
-    <img src="https://github.com/robert-wallis/git-pair.idea/raw/master/docs/screen-shot-gc.png" alt="screenshot" />
+    <img src="https://github.com/RoboPlugins/git-pair.idea/raw/master/docs/screen-shot-gc.png" alt="screenshot" />
     <br />
     <ul>
         <li>Does not depend on or use the git pair plugin, just uses git.</li>
@@ -20,11 +20,12 @@
         <li>Alphabetically sorts, deterministic paired emails.</li>
         <li>Supports email prefix so pair mail can go to a Google Apps alias, prefix+rob+grumpy@example.com (means prefix@example.com on Google).</li>
     </ul>
-    <a href="https://github.com/robert-wallis/git-pair.idea">Source code</a> available on GitHub.
+    <a href="https://github.com/RoboPlugins/git-pair.idea">Source code</a> available on GitHub.
     ]]></description>
 
     <change-notes><![CDATA[
     <ul>
+      <li>v1.4 - Checking <code>$PROJECT/.pairs</code> and then <code>$HOME/.pairs</code>, <code>$HOME</code> is new.
       <li>v1.3 - Respect's <code>global</code> setting, if <code>true</code> then the git name/email for the logged in user will be set (global).</li>
       <li>v1.2 - Fixing missing Files and Path class in JRE 1.6.</li>
       <li>v1.1 - Going back down to JRE 1.6 instead of 1.7 because my pairing station at work doesn't have a reasonable JRE on it.</li>

--- a/src/gitpair/git/GitRunner.java
+++ b/src/gitpair/git/GitRunner.java
@@ -85,8 +85,14 @@ public class GitRunner {
      *
      * @param fullName the current name of the user, for example "Bub".
      */
-    public void setUserName(@NotNull String fullName) {
-        runGitCommand("config", "user.name", fullName);
+    public void setUserName(@NotNull String fullName, boolean global) {
+        if (global) {
+            runGitCommand("config", "--global", "user.name", fullName);
+            // clear the local config, so it won't override our new setting
+            runGitCommand("config", "--unset", "--local", "user.name");
+        } else {
+            runGitCommand("config", "user.name", fullName);
+        }
     }
 
     /**

--- a/src/gitpair/pairing/PairController.java
+++ b/src/gitpair/pairing/PairController.java
@@ -65,7 +65,7 @@ public class PairController {
         String name = generatePairName(currentPair);
 
         if (name != null) {
-            gitRunner.setUserName(name);
+            gitRunner.setUserName(name, pairConfig.shouldChangeGlobalUser());
         }
         if (email != null) {
             gitRunner.setUserEmail(email, pairConfig.shouldChangeGlobalUser());

--- a/tests/gitpair/git/GitRunnerTest.java
+++ b/tests/gitpair/git/GitRunnerTest.java
@@ -84,9 +84,22 @@ public class GitRunnerTest extends LightPlatformCodeInsightFixtureTestCase {
         gitRunner.runGitCommand("config", "user.name", "setup");
 
         // WHEN we run `git config user.name "Test User Name & Stuff"`
-        gitRunner.setUserName("Test User Name & Stuff");
+        gitRunner.setUserName("Test User Name & Stuff", false);
 
         // THEN it should set current user's name
         assertEquals("Test User Name & Stuff", gitRunner.getUserName());
+    }
+
+    public void testSetUserNameGlobal() {
+        // GIVEN a system with git installed and a project configured with git
+        GitRunner gitRunner = new GitRunner(getProject().getBasePath());
+        gitRunner.runGitCommand("init");
+        gitRunner.runGitCommand("config", "user.name", "setup");
+
+        // WHEN we run `git config user.name "Test User Name & Stuff"`
+        gitRunner.setUserName("Test Global User Name", true);
+
+        // THEN it should set current user's name
+        assertEquals("Test Global User Name", gitRunner.getUserName());
     }
 }


### PR DESCRIPTION
* Supports `~/.pairs` now as well as the v1.3 supported `$PROJECT/.pairs`
* Fixed #8, sorry that 2 years ago I didn't look in the code, it was obvious when I was just fixing warnings, and then later I saw issue 8 was the same thing.  So sad that I didn't check it back then.